### PR TITLE
Use busybox image as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN \
   CGO_ENABLED=0 \
   go build -o main cmd/main.go
 
-FROM scratch
+FROM busybox:1.33.1
 COPY --from=builder /build/main /main
 ENTRYPOINT ["/main"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,3 +1,3 @@
-FROM scratch
+FROM busybox:1.33.1
 ENTRYPOINT ["/main"]
 COPY main /


### PR DESCRIPTION
## Description

Reasons for the change:
- The `scratch` container doesn't appear to pick up base config file changes on my server. It does however in docker-compose locally when testing
- The busybox image is very lightweight, adding 1.2MB over `scratch`. `alpine` would be a bit bigger.
- Easier to debug

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Code style update
- [ ] Refactoring
- [ ] CI
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/calvinbui/homer-service-discovery/blob/main/CONTRIBUTING.md)
- [x] I have made corresponding changes the documentation (README.md) if required.
