### PR TITLE
Add missing 'icon' configuration key for header

### DIFF
--- a/pkg/homer/types.go
+++ b/pkg/homer/types.go
@@ -6,6 +6,7 @@ type Config struct {
 	Title             string      `yaml:"title,omitempty"`
 	Subtitle          string      `yaml:"subtitle,omitempty"`
 	Logo              string      `yaml:"logo,omitempty"`
+	Icon              string      `yaml:"icon,omitempty"`
 	Header            bool        `yaml:"header"`
 	Footer            interface{} `yaml:"footer,omitempty"`
 	Columns           string      `yaml:"columns,omitempty"`


### PR DESCRIPTION
## Description

`homer-service-discovery` strips the header `icon` key from the rendered YAML since it is missing from the struct the config is unmarshalled into. This PR adds the missing key, which allows users to set custom header icons if they wish to use one instead of a logo image.

Thanks for this project, this is just what I was looking for to help make an automatic easy-to-use dashboard for all docker services running on a host!

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Code style update
- [ ] Refactoring
- [ ] CI
- [ ] Documentation
- [ ] Tests
- [ ] Other

## Checklist:

- [x] I've read & comply with the [contributing guidelines](https://github.com/calvinbui/homer-service-discovery/blob/main/CONTRIBUTING.md)
- [x] I have made corresponding changes the documentation (README.md) if required.
